### PR TITLE
添加 mainframe 功能

### DIFF
--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -91,59 +91,59 @@
 % 参考自 https://tex.stackexchange.com/a/449294
 \tl_set:Nn \l__mf_textframe_tl
   {
-    \use:x
+    \begin { tikzpicture } [ remember~ picture, overlay ]
+    \exp_last_unbraced:Nx \draw
       {
-        \exp_not:N \tikz [ remember~ picture, overlay ]
-          \exp_not:N \draw
+        [
+          line~ width = \l__mf_line_width_dim,
+          color = \l__mf_color_tl,
+          \l__mf_tikz_style_clist
+        ] % 需要向外偏离一定距离
+          (
             [
-              line~ width = \exp_not:N \l__mf_line_width_dim,
-              color = \exp_not:N \l__mf_color_tl,
-              \l__mf_tikz_style_clist
-            ] % 需要向外偏离一定距离
-            (
-              [
-                xshift = - \exp_not:N \l__mf_left_shift_dim,   % 左偏移
-                yshift = - \exp_not:N \l__mf_bottom_shift_dim, % 下偏移
-              ]
-              current~ page~ text~ area . south~ west % 左下
-            )
-            rectangle
-            (
-              [
-                xshift = \exp_not:N \l__mf_right_shift_dim, % 右偏移
-                yshift = \exp_not:N \l__mf_top_shift_dim,   % 上偏移
-              ]
-              current~ page~ text~ area . north~ east % 右上
-            ) ;
+              xshift = - \l__mf_left_shift_dim,   % 左偏移
+              yshift = - \l__mf_bottom_shift_dim, % 下偏移
+            ]
+            current~ page~ text~ area . south~ west % 左下
+          )
+          rectangle
+          (
+            [
+              xshift = \l__mf_right_shift_dim, % 右偏移
+              yshift = \l__mf_top_shift_dim,   % 上偏移
+            ]
+            current~ page~ text~ area . north~ east % 右上
+          ) ;
       }
+    \end { tikzpicture }
   }
 \tl_set:Nn \l__mf_paperframe_tl
   {
-    \use:x
+    \begin { tikzpicture } [ remember~ picture, overlay ]
+    \exp_last_unbraced:Nx \draw
       {
-        \exp_not:N \tikz [ remember~ picture, overlay ]
-          \exp_not:N \draw
-            [
-              line~ width = \exp_not:N \l__mf_line_width_dim,
-              color = \exp_not:N \l__mf_color_tl,
-              \l__mf_tikz_style_clist
-            ] % 需要向内偏离一定距离
-            (
-              [
-                xshift = \exp_not:N \l__mf_left_shift_dim,   % 左偏移
-                yshift = \exp_not:N \l__mf_bottom_shift_dim, % 下偏移
-              ]
-              current~ page . south~ west % 左下
-            )
-            rectangle
-            (
-              [
-                xshift = - \exp_not:N \l__mf_right_shift_dim, % 右偏移
-                yshift = - \exp_not:N \l__mf_top_shift_dim,   % 上偏移
-              ]
-              current~ page . north~ east % 右上
-            ) ;
+        [
+          line~ width = \l__mf_line_width_dim,
+          color = \l__mf_color_tl,
+          \l__mf_tikz_style_clist
+        ] % 需要向内偏离一定距离
+        (
+          [
+            xshift = \l__mf_left_shift_dim,   % 左偏移
+            yshift = \l__mf_bottom_shift_dim, % 下偏移
+          ]
+          current~ page . south~ west % 左下
+        )
+        rectangle
+        (
+          [
+            xshift = - \l__mf_right_shift_dim, % 右偏移
+            yshift = - \l__mf_top_shift_dim,   % 上偏移
+          ]
+          current~ page . north~ east % 右上
+        ) ;
       }
+    \end { tikzpicture }
   }
 
 % 宏包选项

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -1,8 +1,9 @@
 % !TeX root = ./demo.tex
 %% mainframe.sty 2023/02/11 version V0.1  by Sunben Chiu
 %% mainframe.sty 2023/02/12 version V0.2  by Sunben Chiu
+%% mainframe.sty 2023/02/12 version V0.3  by Sunben Chiu
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesExplPackage{mainframe}{2023-02-12}{0.2}{Sunben Chiu}
+\ProvidesExplPackage{mainframe}{2023-02-12}{0.3}{Sunben Chiu}
 \RequirePackage { tikzpagenodes, atbegshi }
 
 \dim_new:N \l__mf_left_shift_set_dim
@@ -54,6 +55,7 @@
 \cs_generate_variant:Nn \keys_define:nn { nx }
 \keys_define:nn { mainframe }
   {
+    style   .clist_set:N = \l__mf_tikz_style_clist,
     linewidth .dim_set:N = \l__mf_line_width_dim,
     color      .tl_set:N = \l__mf_color_tl,
     linewidth .initial:n = { 0.4pt },
@@ -72,12 +74,13 @@
 
 \cs_new:Npn \__mf_clear_setting:
   {
-    \dim_zero:N \l__mf_left_shift_set_dim
-    \dim_zero:N \l__mf_right_shift_set_dim
-    \dim_zero:N \l__mf_top_shift_set_dim
-    \dim_zero:N \l__mf_bottom_shift_set_dim
-    \dim_set:Nn \l__mf_line_width_dim { 0.4pt }
-    \tl_set:Nn  \l__mf_color_tl       { black }
+    \dim_zero:N    \l__mf_left_shift_set_dim
+    \dim_zero:N    \l__mf_right_shift_set_dim
+    \dim_zero:N    \l__mf_top_shift_set_dim
+    \dim_zero:N    \l__mf_bottom_shift_set_dim
+    \clist_clear:N \l__mf_tikz_style_clist
+    \dim_set:Nn    \l__mf_line_width_dim { 0.4pt }
+    \tl_set:Nn     \l__mf_color_tl       { black }
   }
 \NewDocumentCommand { \mfsetup } { s m }
   {
@@ -88,51 +91,59 @@
 % 参考自 https://tex.stackexchange.com/a/449294
 \tl_set:Nn \l__mf_textframe_tl
   {
-    \tikz [ remember~ picture, overlay ]
-      \draw
-        [
-          line~ width = \l__mf_line_width_dim,
-          color = \l__mf_color_tl
-        ] % 需要向外偏移一定距离
-          (
+    \use:x
+      {
+        \exp_not:N \tikz [ remember~ picture, overlay ]
+          \exp_not:N \draw
             [
-              xshift = - \l__mf_left_shift_dim,   % 左偏移
-              yshift = - \l__mf_bottom_shift_dim, % 下偏移
-            ]
-            current~ page~ text~ area . south~ west % 左下
-          )
-          rectangle
-          (
-            [
-              xshift = \l__mf_right_shift_dim, % 右偏移
-              yshift = \l__mf_top_shift_dim,   % 上偏移
-            ]
-            current~ page~ text~ area . north~ east % 右上
-          ) ;
+              line~ width = \exp_not:N \l__mf_line_width_dim,
+              color = \exp_not:N \l__mf_color_tl,
+              \l__mf_tikz_style_clist
+            ] % 需要向外偏离一定距离
+            (
+              [
+                xshift = - \exp_not:N \l__mf_left_shift_dim,   % 左偏移
+                yshift = - \exp_not:N \l__mf_bottom_shift_dim, % 下偏移
+              ]
+              current~ page~ text~ area . south~ west % 左下
+            )
+            rectangle
+            (
+              [
+                xshift = \exp_not:N \l__mf_right_shift_dim, % 右偏移
+                yshift = \exp_not:N \l__mf_top_shift_dim,   % 上偏移
+              ]
+              current~ page~ text~ area . north~ east % 右上
+            ) ;
+      }
   }
 \tl_set:Nn \l__mf_paperframe_tl
   {
-    \tikz [ remember~ picture, overlay ]
-      \draw
-        [
-          line~ width = \l__mf_line_width_dim,
-          color = \l__mf_color_tl
-        ] % 需要向内偏移一定距离
-        (
-          [
-            xshift = \l__mf_left_shift_dim,   % 左偏移
-            yshift = \l__mf_bottom_shift_dim, % 下偏移
-          ]
-          current~ page . south~ west % 左下
-        )
-        rectangle
-        (
-          [
-            xshift = - \l__mf_right_shift_dim, % 右偏移
-            yshift = - \l__mf_top_shift_dim,   % 上偏移
-          ]
-          current~ page . north~ east % 右上
-        ) ;
+    \use:x
+      {
+        \exp_not:N \tikz [ remember~ picture, overlay ]
+          \exp_not:N \draw
+            [
+              line~ width = \exp_not:N \l__mf_line_width_dim,
+              color = \exp_not:N \l__mf_color_tl,
+              \l__mf_tikz_style_clist
+            ] % 需要向内偏离一定距离
+            (
+              [
+                xshift = \exp_not:N \l__mf_left_shift_dim,   % 左偏移
+                yshift = \exp_not:N \l__mf_bottom_shift_dim, % 下偏移
+              ]
+              current~ page . south~ west % 左下
+            )
+            rectangle
+            (
+              [
+                xshift = - \exp_not:N \l__mf_right_shift_dim, % 右偏移
+                yshift = - \exp_not:N \l__mf_top_shift_dim,   % 上偏移
+              ]
+              current~ page . north~ east % 右上
+            ) ;
+      }
   }
 
 % 宏包选项

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -2,8 +2,9 @@
 %% mainframe.sty 2023/02/11 version V0.1  by Sunben Chiu
 %% mainframe.sty 2023/02/12 version V0.2  by Sunben Chiu
 %% mainframe.sty 2023/02/12 version V0.3  by Sunben Chiu
+%% mainframe.sty 2023/02/13 version V0.4  by Sunben Chiu
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesExplPackage{mainframe}{2023-02-12}{0.3}{Sunben Chiu}
+\ProvidesExplPackage{mainframe}{2023-02-13}{0.4}{Sunben Chiu}
 \RequirePackage { tikzpagenodes, atbegshi }
 
 \dim_new:N \l__mf_left_shift_set_dim
@@ -14,7 +15,7 @@
 \dim_new:N \l__mf_top_shift_dim
 \dim_new:N \l__mf_bottom_shift_set_dim
 \dim_new:N \l__mf_bottom_shift_dim
-\tl_new:N  \l__mf_frame_tl
+\tl_new:N  \l__mf_innerframe_tl
 
 \clist_map_inline:nn { set, add }
   {
@@ -37,22 +38,22 @@
 
 \cs_new:Npn \__mf_plus_key_aux_lrtb:n #1
   {
-    % #1  .dim_set:N = \exp_not:c { l__mf_ #1 _shift_set_dim }, % 毋须预定义变量
     #1  .dim_set:c = { l__mf_ #1 _shift_set_dim }, % 需要预定义变量
     #1  .initial:n = { 0pt },
-    #1   + .code:n = { \dim_add:cn { l__mf_ #1 _shift_set_dim } {####1} },
-    #1 ~ + .code:n = { \dim_add:cn { l__mf_ #1 _shift_set_dim } {####1} }
+    #1   + .code:n = { \dim_add:cn { l__mf_ #1 _shift_set_dim } {##1} },
+    #1 ~ + .code:n = { \dim_add:cn { l__mf_ #1 _shift_set_dim } {##1} }
   }
 \cs_new:Npn \__mf_plus_key_aux_shift:n #1
   {
-    #1     .code:n = { \__mf_shift_set:nnn { set } {#1} {####1} },
-    #1 ~ + .code:n = { \__mf_shift_set:nnn { add } {#1} {####1} },
-    #1   + .code:n = { \__mf_shift_set:nnn { add } {#1} {####1} }
+    #1     .code:n = { \__mf_shift_set:nnn { set } {#1} {##1} },
+    #1 ~ + .code:n = { \__mf_shift_set:nnn { add } {#1} {##1} },
+    #1   + .code:n = { \__mf_shift_set:nnn { add } {#1} {##1} }
   }
 \cs_new:Npn \__mf_shift_set:nnn #1#2#3 { \use:c { __mf_ #2 _ #1 : n } {#3} }
 
 % 用户接口选项
-\cs_generate_variant:Nn \keys_define:nn { nx }
+% 若用 \keys_define:nx 则上面应该用 ####1 而非 ##1 ，这是 e-type 和 x-type 的区别
+\cs_generate_variant:Nn \keys_define:nn { ne }
 \keys_define:nn { mainframe }
   {
     linewidth .dim_set:N = \l__mf_line_width_dim,
@@ -63,7 +64,7 @@
     style   +    .code:n = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
     style ~ +    .code:n = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
   }
-\keys_define:nx { mainframe }
+\keys_define:ne { mainframe }
   {
     \__mf_plus_key_aux_lrtb:n  { left   },
     \__mf_plus_key_aux_lrtb:n  { right  },
@@ -93,7 +94,7 @@
 % 参考自 https://tex.stackexchange.com/a/449294
 % #1: anchor point, #2: style clist
 % #3: left shift, #4: bottom shift, #5: right shift, #6: top shift
-\cs_new:Npn \__mf_make_frame:nnnnnn #1#2#3#4#5#6
+\cs_new:Npn \__mf_make_innerframe:nnnnnn #1#2#3#4#5#6
   {
     \tikz [ remember~ picture, overlay ]
       \draw
@@ -113,10 +114,10 @@
         ) ;
   }
 
-\cs_generate_variant:Nn \__mf_make_frame:nnnnnn { nxnnnn }
+\cs_generate_variant:Nn \__mf_make_innerframe:nnnnnn { nxnnnn }
 \tl_set:Nn \l__mf_textframe_tl
   {
-    \__mf_make_frame:nxnnnn
+    \__mf_make_innerframe:nxnnnn
       { current~ page~ text~ area }
       { \l__mf_tikz_style_clist }
       { - \l__mf_left_shift_dim }
@@ -126,7 +127,7 @@
   }
 \tl_set:Nn \l__mf_paperframe_tl
   {
-    \__mf_make_frame:nxnnnn
+    \__mf_make_innerframe:nxnnnn
       { current~ page }
       { \l__mf_tikz_style_clist }
       { \l__mf_left_shift_dim }
@@ -138,8 +139,8 @@
 % 宏包选项
 \keys_define:nn { mainframe / option }
   {
-    allpage      .code:n =  { \tl_set_eq:NN \l__mf_frame_tl \l__mf_textframe_tl  },
-    allpage*     .code:n =  { \tl_set_eq:NN \l__mf_frame_tl \l__mf_paperframe_tl },
+    allpage      .code:n =  { \tl_set_eq:NN \l__mf_innerframe_tl \l__mf_textframe_tl  },
+    allpage*     .code:n =  { \tl_set_eq:NN \l__mf_innerframe_tl \l__mf_paperframe_tl },
   }
 % mainframe / option 继承 mainframe 的所有选项
 \keys_define:nn { }
@@ -154,32 +155,42 @@
     \dim_set:Nn \l__mf_top_shift_dim    { \l__mf_line_width_dim / 2 + \l__mf_top_shift_set_dim    }
     \dim_set:Nn \l__mf_bottom_shift_dim { \l__mf_line_width_dim / 2 + \l__mf_bottom_shift_set_dim }
   }
+\tl_set:Nn \l__mf_frame_tl { \__mf_update_setting: \l__mf_innerframe_tl }
+
 % 参考自 https://tex.stackexchange.com/a/296862
-\AtBeginShipout { \AtBeginShipoutAddToBox { \__mf_update_setting: \l__mf_frame_tl } }
+\AtBeginShipout { \AtBeginShipoutAddToBox { \l__mf_frame_tl } }
 
 
-
-\NewDocumentEnvironment { mfpage } { O{} }
+% #1: environment name, #2: *, #3: tl val
+\cs_new:Npn \__mf_new_environment_from:nnN #1#2#3
   {
-    \cleardoublepage
-    \tl_if_blank:nF {#1} { \mfsetup {#1} }
-    \tl_set_eq:NN \l__mf_frame_tl \l__mf_textframe_tl
-  }
-  {
-    \cleardoublepage
-    \tl_clear:N \l__mf_frame_tl
+    \NewDocumentEnvironment {#1} { O{} }
+      {
+        \cleardoublepage
+        \tl_if_blank:nF {##1} { \mfsetup #2 {##1} }
+        \tl_set_eq:NN \l__mf_innerframe_tl #3
+      }
+      {
+        \cleardoublepage
+        \tl_clear:N \l__mf_innerframe_tl
+      }
   }
 
+% #1: environment name, #2: tl val
+\cs_new:Npn \__mf_new_innerframe:nN #1#2
+  { \__mf_new_environment_from:nnN {#1} {   } #2 }
+\cs_new:Npn \__mf_new_innerframe_star:nN #1#2
+  { \__mf_new_environment_from:nnN {#1} { * } #2 }
+
+\__mf_new_innerframe:nN { mftext  } \l__mf_textframe_tl
+\__mf_new_innerframe:nN { mfpaper } \l__mf_paperframe_tl
+\__mf_new_innerframe_star:nN { mftext*  } \l__mf_textframe_tl
+\__mf_new_innerframe_star:nN { mfpaper* } \l__mf_paperframe_tl
+
+\NewDocumentEnvironment { mfpage  } { O{} }
+  { \begin { mftext  } [#1] } { \end { mftext  } }
 \NewDocumentEnvironment { mfpage* } { O{} }
-  {
-    \cleardoublepage
-    \tl_if_blank:nF {#1} { \mfsetup {#1} }
-    \tl_set_eq:NN \l__mf_frame_tl \l__mf_paperframe_tl
-  }
-  {
-    \cleardoublepage
-    \tl_clear:N \l__mf_frame_tl
-  }
+  { \begin { mftext* } [#1] } { \end { mftext* } }
 
 \endinput
 %%

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -56,11 +56,13 @@
 \cs_generate_variant:Nn \keys_define:nn { ne }
 \keys_define:nn { mainframe }
   {
-    linewidth .dim_set:N = \l__mf_line_width_dim,
-    linewidth .initial:n = { 0.4pt },
-    style   .clist_set:N = \l__mf_tikz_style_clist,
-    style   +    .code:n = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
-    style ~ +    .code:n = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
+    linewidth .dim_set:N  = \l__mf_line_width_dim,
+    linewidth .initial:n  = { 0.4pt },
+    linewidth   + .code:n = { \dim_add:Nn \l__mf_line_width_dim {#1} },
+    linewidth ~ + .code:n = { \dim_add:Nn \l__mf_line_width_dim {#1} },
+    style   .clist_set:N  = \l__mf_tikz_style_clist,
+    style   +    .code:n  = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
+    style ~ +    .code:n  = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
   }
 \keys_define:ne { mainframe }
   {

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -165,7 +165,7 @@
     \NewDocumentEnvironment {#1} { O{} }
       {
         \cleardoublepage
-        \tl_if_blank:nF {##1} { \mfsetup #2 {##1} }
+        \mfsetup #2 {##1}
         \tl_set_eq:NN \l__mf_innerframe_tl #3
       }
       {

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -57,9 +57,7 @@
 \keys_define:nn { mainframe }
   {
     linewidth .dim_set:N = \l__mf_line_width_dim,
-    color      .tl_set:N = \l__mf_color_tl,
     linewidth .initial:n = { 0.4pt },
-    color     .initial:n = { black },
     style   .clist_set:N = \l__mf_tikz_style_clist,
     style   +    .code:n = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
     style ~ +    .code:n = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
@@ -81,9 +79,8 @@
     \dim_zero:N    \l__mf_right_shift_set_dim
     \dim_zero:N    \l__mf_top_shift_set_dim
     \dim_zero:N    \l__mf_bottom_shift_set_dim
-    \clist_clear:N \l__mf_tikz_style_clist
     \dim_set:Nn    \l__mf_line_width_dim { 0.4pt }
-    \tl_set:Nn     \l__mf_color_tl       { black }
+    \clist_clear:N \l__mf_tikz_style_clist
   }
 \NewDocumentCommand { \mfsetup } { s m }
   {
@@ -100,7 +97,6 @@
       \draw
         [
           line~ width = \l__mf_line_width_dim, % 需要向内/外偏离一定距离
-          draw        = \l__mf_color_tl,
           #2
         ]
         (

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -1,7 +1,9 @@
 % !TeX root = ./demo.tex
+%% mainframe.sty 2023/02/11 version V0.1  by Sunben Chiu
 %% mainframe.sty 2023/02/12 version V0.2  by Sunben Chiu
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesExplPackage{mainframe}{2023-02-12}{0.2}{Sunben Chiu}
+\RequirePackage { tikzpagenodes, atbegshi }
 
 \dim_new:N \l__mf_left_shift_set_dim
 \dim_new:N \l__mf_left_shift_dim
@@ -13,38 +15,23 @@
 \dim_new:N \l__mf_bottom_shift_dim
 \tl_new:N  \l__mf_frame_tl
 
-\RequirePackage { tikzpagenodes, atbegshi }
-
-\cs_new:Npn \__mf_xshift_set:n #1
+\clist_map_inline:nn { set, add }
   {
-    \dim_set:Nn \l__mf_left_shift_set_dim   {#1}
-    \dim_set:Nn \l__mf_right_shift_set_dim  {#1}
-  }
-\cs_new:Npn \__mf_yshift_set:n #1
-  {
-    \dim_set:Nn \l__mf_top_shift_set_dim    {#1}
-    \dim_set:Nn \l__mf_bottom_shift_set_dim {#1}
-  }
-\cs_new:Npn \__mf_shift_set:n #1
-  {
-    \__mf_xshift_set:n {#1}
-    \__mf_yshift_set:n {#1}
-  }
-
-\cs_new:Npn \__mf_xshift_add:n #1
-  {
-    \dim_add:Nn \l__mf_left_shift_set_dim   {#1}
-    \dim_add:Nn \l__mf_right_shift_set_dim  {#1}
-  }
-\cs_new:Npn \__mf_yshift_add:n #1
-  {
-    \dim_add:Nn \l__mf_top_shift_set_dim    {#1}
-    \dim_add:Nn \l__mf_bottom_shift_set_dim {#1}
-  }
-\cs_new:Npn \__mf_shift_add:n #1
-  {
-    \__mf_xshift_add:n {#1}
-    \__mf_yshift_add:n {#1}
+    \cs_new:cpn { __mf_xshift_ #1 : n } ##1
+      {
+        \use:c { dim_ #1 : Nn } \l__mf_left_shift_set_dim   {##1}
+        \use:c { dim_ #1 : Nn } \l__mf_right_shift_set_dim  {##1}
+      }
+    \cs_new:cpn { __mf_yshift_ #1 : n } ##1
+      {
+        \use:c { dim_ #1 : Nn } \l__mf_top_shift_set_dim    {##1}
+        \use:c { dim_ #1 : Nn } \l__mf_bottom_shift_set_dim {##1}
+      }
+    \cs_new:cpn { __mf_shift_ #1 : n } ##1
+      {
+        \use:c { __mf_xshift_ #1 : n } {##1}
+        \use:c { __mf_yshift_ #1 : n } {##1}
+      }
   }
 
 \cs_new:Npn \__mf_plus_key_aux_lrtb:n #1
@@ -106,7 +93,7 @@
         [
           line~ width = \l__mf_line_width_dim,
           color = \l__mf_color_tl
-        ] % 需要向外偏离一定距离
+        ] % 需要向外偏移一定距离
           (
             [
               xshift = - \l__mf_left_shift_dim,   % 左偏移
@@ -130,7 +117,7 @@
         [
           line~ width = \l__mf_line_width_dim,
           color = \l__mf_color_tl
-        ] % 需要向内偏离一定距离
+        ] % 需要向内偏移一定距离
         (
           [
             xshift = \l__mf_left_shift_dim,   % 左偏移

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -89,61 +89,48 @@
   }
 
 % 参考自 https://tex.stackexchange.com/a/449294
-\tl_set:Nn \l__mf_textframe_tl
+% #1: anchor point, #2: style clist
+% #3: left shift, #4: bottom shift, #5: right shift, #6: top shift
+\cs_new:Npn \__mf_make_frame:nnnnnn #1#2#3#4#5#6
   {
-    \begin { tikzpicture } [ remember~ picture, overlay ]
-    \exp_last_unbraced:Nx \draw
-      {
+    \tikz [ remember~ picture, overlay ]
+      \draw
         [
-          line~ width = \l__mf_line_width_dim,
-          color = \l__mf_color_tl,
-          \l__mf_tikz_style_clist
-        ] % 需要向外偏离一定距离
-          (
-            [
-              xshift = - \l__mf_left_shift_dim,   % 左偏移
-              yshift = - \l__mf_bottom_shift_dim, % 下偏移
-            ]
-            current~ page~ text~ area . south~ west % 左下
-          )
-          rectangle
-          (
-            [
-              xshift = \l__mf_right_shift_dim, % 右偏移
-              yshift = \l__mf_top_shift_dim,   % 上偏移
-            ]
-            current~ page~ text~ area . north~ east % 右上
-          ) ;
-      }
-    \end { tikzpicture }
-  }
-\tl_set:Nn \l__mf_paperframe_tl
-  {
-    \begin { tikzpicture } [ remember~ picture, overlay ]
-    \exp_last_unbraced:Nx \draw
-      {
-        [
-          line~ width = \l__mf_line_width_dim,
-          color = \l__mf_color_tl,
-          \l__mf_tikz_style_clist
-        ] % 需要向内偏离一定距离
+          line~ width = \l__mf_line_width_dim, % 需要向内/外偏离一定距离
+          draw        = \l__mf_color_tl,
+          #2
+        ]
         (
-          [
-            xshift = \l__mf_left_shift_dim,   % 左偏移
-            yshift = \l__mf_bottom_shift_dim, % 下偏移
-          ]
-          current~ page . south~ west % 左下
+          [ xshift = #3, yshift = #4 ]
+          #1 . south~ west % 左下
         )
         rectangle
         (
-          [
-            xshift = - \l__mf_right_shift_dim, % 右偏移
-            yshift = - \l__mf_top_shift_dim,   % 上偏移
-          ]
-          current~ page . north~ east % 右上
+          [ xshift = #5, yshift = #6 ]
+          #1 . north~ east % 右上
         ) ;
-      }
-    \end { tikzpicture }
+  }
+
+\cs_generate_variant:Nn \__mf_make_frame:nnnnnn { nxnnnn }
+\tl_set:Nn \l__mf_textframe_tl
+  {
+    \__mf_make_frame:nxnnnn
+      { current~ page~ text~ area }
+      { \l__mf_tikz_style_clist }
+      { - \l__mf_left_shift_dim }
+      { - \l__mf_bottom_shift_dim }
+      { \l__mf_right_shift_dim }
+      { \l__mf_top_shift_dim }
+  }
+\tl_set:Nn \l__mf_paperframe_tl
+  {
+    \__mf_make_frame:nxnnnn
+      { current~ page }
+      { \l__mf_tikz_style_clist }
+      { \l__mf_left_shift_dim }
+      { \l__mf_bottom_shift_dim }
+      { - \l__mf_right_shift_dim }
+      { - \l__mf_top_shift_dim }
   }
 
 % 宏包选项

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -55,11 +55,13 @@
 \cs_generate_variant:Nn \keys_define:nn { nx }
 \keys_define:nn { mainframe }
   {
-    style   .clist_set:N = \l__mf_tikz_style_clist,
     linewidth .dim_set:N = \l__mf_line_width_dim,
     color      .tl_set:N = \l__mf_color_tl,
     linewidth .initial:n = { 0.4pt },
     color     .initial:n = { black },
+    style   .clist_set:N = \l__mf_tikz_style_clist,
+    style   +    .code:n = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
+    style ~ +    .code:n = { \clist_put_right:Nn \l__mf_tikz_style_clist {#1} },
   }
 \keys_define:nx { mainframe }
   {

--- a/tools/mainframe.sty
+++ b/tools/mainframe.sty
@@ -1,37 +1,199 @@
 % !TeX root = ./demo.tex
-%% mainframe.sty 2023/02/11 version V0.1  by Sunben Chiu
-
+%% mainframe.sty 2023/02/12 version V0.2  by Sunben Chiu
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesExplPackage{mainframe}{2023-02-11}{0.1}{Sunben Chiu}
+\ProvidesExplPackage{mainframe}{2023-02-12}{0.2}{Sunben Chiu}
+
+\dim_new:N \l__mf_left_shift_set_dim
+\dim_new:N \l__mf_left_shift_dim
+\dim_new:N \l__mf_right_shift_set_dim
+\dim_new:N \l__mf_right_shift_dim
+\dim_new:N \l__mf_top_shift_set_dim
+\dim_new:N \l__mf_top_shift_dim
+\dim_new:N \l__mf_bottom_shift_set_dim
+\dim_new:N \l__mf_bottom_shift_dim
+\tl_new:N  \l__mf_frame_tl
 
 \RequirePackage { tikzpagenodes, atbegshi }
 
+\cs_new:Npn \__mf_xshift_set:n #1
+  {
+    \dim_set:Nn \l__mf_left_shift_set_dim   {#1}
+    \dim_set:Nn \l__mf_right_shift_set_dim  {#1}
+  }
+\cs_new:Npn \__mf_yshift_set:n #1
+  {
+    \dim_set:Nn \l__mf_top_shift_set_dim    {#1}
+    \dim_set:Nn \l__mf_bottom_shift_set_dim {#1}
+  }
+\cs_new:Npn \__mf_shift_set:n #1
+  {
+    \__mf_xshift_set:n {#1}
+    \__mf_yshift_set:n {#1}
+  }
+
+\cs_new:Npn \__mf_xshift_add:n #1
+  {
+    \dim_add:Nn \l__mf_left_shift_set_dim   {#1}
+    \dim_add:Nn \l__mf_right_shift_set_dim  {#1}
+  }
+\cs_new:Npn \__mf_yshift_add:n #1
+  {
+    \dim_add:Nn \l__mf_top_shift_set_dim    {#1}
+    \dim_add:Nn \l__mf_bottom_shift_set_dim {#1}
+  }
+\cs_new:Npn \__mf_shift_add:n #1
+  {
+    \__mf_xshift_add:n {#1}
+    \__mf_yshift_add:n {#1}
+  }
+
+\cs_new:Npn \__mf_plus_key_aux_lrtb:n #1
+  {
+    % #1  .dim_set:N = \exp_not:c { l__mf_ #1 _shift_set_dim }, % 毋须预定义变量
+    #1  .dim_set:c = { l__mf_ #1 _shift_set_dim }, % 需要预定义变量
+    #1  .initial:n = { 0pt },
+    #1   + .code:n = { \dim_add:cn { l__mf_ #1 _shift_set_dim } {####1} },
+    #1 ~ + .code:n = { \dim_add:cn { l__mf_ #1 _shift_set_dim } {####1} }
+  }
+\cs_new:Npn \__mf_plus_key_aux_shift:n #1
+  {
+    #1     .code:n = { \__mf_shift_set:nnn { set } {#1} {####1} },
+    #1 ~ + .code:n = { \__mf_shift_set:nnn { add } {#1} {####1} },
+    #1   + .code:n = { \__mf_shift_set:nnn { add } {#1} {####1} }
+  }
+\cs_new:Npn \__mf_shift_set:nnn #1#2#3 { \use:c { __mf_ #2 _ #1 : n } {#3} }
+
+% 用户接口选项
+\cs_generate_variant:Nn \keys_define:nn { nx }
+\keys_define:nn { mainframe }
+  {
+    linewidth .dim_set:N = \l__mf_line_width_dim,
+    color      .tl_set:N = \l__mf_color_tl,
+    linewidth .initial:n = { 0.4pt },
+    color     .initial:n = { black },
+  }
+\keys_define:nx { mainframe }
+  {
+    \__mf_plus_key_aux_lrtb:n  { left   },
+    \__mf_plus_key_aux_lrtb:n  { right  },
+    \__mf_plus_key_aux_lrtb:n  { top    },
+    \__mf_plus_key_aux_lrtb:n  { bottom },
+    \__mf_plus_key_aux_shift:n { shift  },
+    \__mf_plus_key_aux_shift:n { xshift },
+    \__mf_plus_key_aux_shift:n { yshift },
+  }
+
+\cs_new:Npn \__mf_clear_setting:
+  {
+    \dim_zero:N \l__mf_left_shift_set_dim
+    \dim_zero:N \l__mf_right_shift_set_dim
+    \dim_zero:N \l__mf_top_shift_set_dim
+    \dim_zero:N \l__mf_bottom_shift_set_dim
+    \dim_set:Nn \l__mf_line_width_dim { 0.4pt }
+    \tl_set:Nn  \l__mf_color_tl       { black }
+  }
+\NewDocumentCommand { \mfsetup } { s m }
+  {
+    \IfBooleanT {#1} { \__mf_clear_setting: }
+    \keys_set:nn { mainframe } {#2}
+  }
+
 % 参考自 https://tex.stackexchange.com/a/449294
-\tl_set:Nn \g__mf_main_frame_tl
+\tl_set:Nn \l__mf_textframe_tl
   {
     \tikz [ remember~ picture, overlay ]
       \draw
-        ( current~ page~ text~ area . south~ west )
+        [
+          line~ width = \l__mf_line_width_dim,
+          color = \l__mf_color_tl
+        ] % 需要向外偏离一定距离
+          (
+            [
+              xshift = - \l__mf_left_shift_dim,   % 左偏移
+              yshift = - \l__mf_bottom_shift_dim, % 下偏移
+            ]
+            current~ page~ text~ area . south~ west % 左下
+          )
+          rectangle
+          (
+            [
+              xshift = \l__mf_right_shift_dim, % 右偏移
+              yshift = \l__mf_top_shift_dim,   % 上偏移
+            ]
+            current~ page~ text~ area . north~ east % 右上
+          ) ;
+  }
+\tl_set:Nn \l__mf_paperframe_tl
+  {
+    \tikz [ remember~ picture, overlay ]
+      \draw
+        [
+          line~ width = \l__mf_line_width_dim,
+          color = \l__mf_color_tl
+        ] % 需要向内偏离一定距离
+        (
+          [
+            xshift = \l__mf_left_shift_dim,   % 左偏移
+            yshift = \l__mf_bottom_shift_dim, % 下偏移
+          ]
+          current~ page . south~ west % 左下
+        )
         rectangle
-        ( current~ page~ text~ area . north~ east ) ;
+        (
+          [
+            xshift = - \l__mf_right_shift_dim, % 右偏移
+            yshift = - \l__mf_top_shift_dim,   % 上偏移
+          ]
+          current~ page . north~ east % 右上
+        ) ;
   }
 
+% 宏包选项
+\keys_define:nn { mainframe / option }
+  {
+    allpage      .code:n =  { \tl_set_eq:NN \l__mf_frame_tl \l__mf_textframe_tl  },
+    allpage*     .code:n =  { \tl_set_eq:NN \l__mf_frame_tl \l__mf_paperframe_tl },
+  }
+% mainframe / option 继承 mainframe 的所有选项
+\keys_define:nn { }
+  {  mainframe / option .inherit:n = { mainframe } }
+\ProcessKeysOptions { mainframe / option }
+
+
+\cs_new:Npn \__mf_update_setting:
+  {
+    \dim_set:Nn \l__mf_left_shift_dim   { \l__mf_line_width_dim / 2 + \l__mf_left_shift_set_dim   }
+    \dim_set:Nn \l__mf_right_shift_dim  { \l__mf_line_width_dim / 2 + \l__mf_right_shift_set_dim  }
+    \dim_set:Nn \l__mf_top_shift_dim    { \l__mf_line_width_dim / 2 + \l__mf_top_shift_set_dim    }
+    \dim_set:Nn \l__mf_bottom_shift_dim { \l__mf_line_width_dim / 2 + \l__mf_bottom_shift_set_dim }
+  }
 % 参考自 https://tex.stackexchange.com/a/296862
-\tl_new:N \g__mf_frame_tl
-\AtBeginShipout { \AtBeginShipoutAddToBox { \g__mf_frame_tl } }
+\AtBeginShipout { \AtBeginShipoutAddToBox { \__mf_update_setting: \l__mf_frame_tl } }
 
 
-\NewDocumentEnvironment { mfpage } { }
+
+\NewDocumentEnvironment { mfpage } { O{} }
   {
     \cleardoublepage
-    \tl_gset_eq:NN \g__mf_frame_tl \g__mf_main_frame_tl
+    \tl_if_blank:nF {#1} { \mfsetup {#1} }
+    \tl_set_eq:NN \l__mf_frame_tl \l__mf_textframe_tl
   }
   {
     \cleardoublepage
-    \tl_gclear:N \g__mf_frame_tl
+    \tl_clear:N \l__mf_frame_tl
+  }
+
+\NewDocumentEnvironment { mfpage* } { O{} }
+  {
+    \cleardoublepage
+    \tl_if_blank:nF {#1} { \mfsetup {#1} }
+    \tl_set_eq:NN \l__mf_frame_tl \l__mf_paperframe_tl
+  }
+  {
+    \cleardoublepage
+    \tl_clear:N \l__mf_frame_tl
   }
 
 \endinput
 %%
 %% End of file `mainframe.sty'.
-


### PR DESCRIPTION
## 用户接口

1. `\mfsetup` 命令，设置方框属性
2. `mftext`, `mfpaper` 环境，使用已设置的属性开启一个画 **版心** 方框的环境
3. `mftext*`, `mfpaper*` 环境，使用已设置的属性开启一个画 **纸张** 方框的环境
4. `mfpage`, `mfpage*` 环境，目前功能分别与 `mftext`, `mftext*` 等价，以后可能添加其他功能

## 属性

下列属性均提供 `attr={xxx}` 和 `attr+={xxx}` 的使用格式。除特殊说明外，均可用于宏包选项、`\mfsetup`命令必选参数和 `mftext`, `mftext*`, `mfpaper`, `mfpaper*`, `mfpage`, `mfpage*` 环境的可选参数

1. `linewidth`: 线宽
2. `left`, `right`, `top`, `bottom`: 偏移量。 `mftext` 环境为向外偏移， `mfpaper` 环境为向内偏移
3. `xshift`, `yshift`: 同时设置左右、上下偏移量
4. `shift`: 同时设置上下左右偏移量
5. `style`: 设置 tikz 属性，用于定制好看的样式
6. `allpage` (**仅用于宏包选项**): 当前文档的所有页都画 **版心** 方框
7. `allpage*` (**仅用于宏包选项**): 当前文档的所有页都画 **纸张** 方框